### PR TITLE
Add fftw3

### DIFF
--- a/com.cubicsdr.App.json
+++ b/com.cubicsdr.App.json
@@ -114,6 +114,12 @@
             "make-args": ["-j4"],
             "sources": [ {"type": "git", "url": "https://github.com/pothosware/SoapyHackRF.git" } ],
 			"modules": [ {
+                "name": "libfftw3",
+                "config-opts": ["--enable-float"],
+                "make-args": ["-j4"],
+                "sources": [ {"type": "archive", "url": "http://www.fftw.org/fftw-3.3.6-pl1.tar.gz", "sha256": "1ef4aa8427d9785839bc767f3eb6a84fcb5e9a37c31ed77a04e7e047519a183d" } ]
+            },
+	    {
                 "name": "libhackrf",
                 "cmake": true,
                 "subdir": "host",


### PR DESCRIPTION
Newer versions of libhackrf require fftw3. This patch adds that package.