### PR TITLE
Update to version 3.22 of the GNOME runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Install Gnome Runtime and Sdk, if 'install' steps fail just run again to retry/r
 ```
 $ wget https://sdk.gnome.org/keys/gnome-sdk.gpg
 $ sudo flatpak remote-add --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
-$ flatpak install gnome org.gnome.Platform 3.20
-$ flatpak install gnome org.gnome.Sdk 3.20
+$ flatpak install gnome org.gnome.Platform 3.22
+$ flatpak install gnome org.gnome.Sdk 3.22
 ```
 
 Commands:

--- a/com.cubicsdr.App.json
+++ b/com.cubicsdr.App.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.cubicsdr.App",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.20",
+    "runtime-version": "3.22",
     "sdk": "org.gnome.Sdk",
     "command": "CubicSDR",
     "finish-args": [


### PR DESCRIPTION
3.22 is currently the latest stable version of that runtime. A lot more apps use it than the 3.20 runtime, so more users are likely to have it installed already.